### PR TITLE
fix: update insecure tar dependency

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,6 +31,8 @@ runs:
     - name: Install dependencies
       if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: |
-        SKIP_YARN_COREPACK_CHECK=1 yarn install --cwd example --frozen-lockfile
-        SKIP_YARN_COREPACK_CHECK=1 yarn install --frozen-lockfile
+        yarn install --cwd example --frozen-lockfile
+        yarn install --frozen-lockfile
       shell: bash
+      env:
+        SKIP_YARN_COREPACK_CHECK: '1'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Enable Corepack before setting up Node
       shell: bash
-      run: corepack enable
+      run: corepack --version && corepack enable
 
     - name: Setup Node.js
       uses: actions/setup-node@v3

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Enable Corepack before setting up Node
       shell: bash
       run: |
-        yarn set version 1.22.15
+        npm install -g yarn@1.22.15
         yarn --version
         npm install -g corepack@0.24.0
         corepack --version

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,5 +32,5 @@ runs:
       if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: |
         SKIP_YARN_COREPACK_CHECK=1 yarn install --cwd example --frozen-lockfile
-        yarn install --frozen-lockfile
+        SKIP_YARN_COREPACK_CHECK=1 yarn install --frozen-lockfile
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Enable Corepack before setting up Node
       shell: bash
-      run: corepack --version && corepack enable
+      run: npm install -g corepack@0.24.0 && corepack --version && corepack enable
 
     - name: Setup Node.js
       uses: actions/setup-node@v3

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,15 +4,6 @@ description: Setup Node.js and install dependencies
 runs:
   using: composite
   steps:
-    # - name: Enable Corepack before setting up Node
-    #   shell: bash
-    #   run: |
-    #     npm install -g yarn@1.22.15
-    #     yarn --version
-    #     npm install -g corepack@0.24.0
-    #     corepack --version
-    #     corepack enable
-
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,9 +7,8 @@ runs:
     - name: Enable Corepack before setting up Node
       shell: bash
       run: |
-        npm install -g yarn@1.22.15
+        yarn policies set-version
         yarn --version
-        yarn set version 1.22.15
         npm install -g corepack@0.24.0
         corepack --version
         corepack enable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,6 +4,10 @@ description: Setup Node.js and install dependencies
 runs:
   using: composite
   steps:
+    - name: Enable Corepack before setting up Node
+      shell: bash
+      run: corepack enable
+
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,10 +6,10 @@ runs:
   steps:
     - name: Enable Corepack before setting up Node
       shell: bash
-      run: /
-        npm install -g yarn@1.22.15 /
-        npm install -g corepack@0.24.0 && /
-        corepack --version && /
+      run: |
+        npm install -g yarn@1.22.15 |
+        npm install -g corepack@0.24.0 && |
+        corepack --version && |
         corepack enable
 
     - name: Setup Node.js

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,6 +9,7 @@ runs:
       run: |
         npm install -g yarn@1.22.15
         yarn --version
+        yarn set version 1.22.15
         npm install -g corepack@0.24.0
         corepack --version
         corepack enable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Enable Corepack before setting up Node
       shell: bash
       run: |
-        yarn policies set-version
+        yarn set version 1.22.15
         yarn --version
         npm install -g corepack@0.24.0
         corepack --version

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,14 +4,14 @@ description: Setup Node.js and install dependencies
 runs:
   using: composite
   steps:
-    - name: Enable Corepack before setting up Node
-      shell: bash
-      run: |
-        npm install -g yarn@1.22.15
-        yarn --version
-        npm install -g corepack@0.24.0
-        corepack --version
-        corepack enable
+    # - name: Enable Corepack before setting up Node
+    #   shell: bash
+    #   run: |
+    #     npm install -g yarn@1.22.15
+    #     yarn --version
+    #     npm install -g corepack@0.24.0
+    #     corepack --version
+    #     corepack enable
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -31,6 +31,6 @@ runs:
     - name: Install dependencies
       if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: |
-        yarn install --cwd example --frozen-lockfile
+        SKIP_YARN_COREPACK_CHECK=1 yarn install --cwd example --frozen-lockfile
         yarn install --frozen-lockfile
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,6 +8,7 @@ runs:
       shell: bash
       run: |
         npm install -g yarn@1.22.15
+        yarn --version
         npm install -g corepack@0.24.0
         corepack --version
         corepack enable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,9 +7,9 @@ runs:
     - name: Enable Corepack before setting up Node
       shell: bash
       run: |
-        npm install -g yarn@1.22.15 |
-        npm install -g corepack@0.24.0 && |
-        corepack --version && |
+        npm install -g yarn@1.22.15
+        npm install -g corepack@0.24.0
+        corepack --version
         corepack enable
 
     - name: Setup Node.js

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,11 @@ runs:
   steps:
     - name: Enable Corepack before setting up Node
       shell: bash
-      run: npm install -g corepack@0.24.0 && corepack --version && corepack enable
+      run: /
+        npm install -g yarn@1.22.15 /
+        npm install -g corepack@0.24.0 && /
+        corepack --version && /
+        corepack enable
 
     - name: Setup Node.js
       uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    env:
+      SKIP_YARN_COREPACK_CHECK: '1'
 
     steps:
       - name: Checkout

--- a/.trivyignore
+++ b/.trivyignore
@@ -21,3 +21,7 @@ CVE-2022-46175
 # shell-quote (nodejs-mobile-react-native app)
 
 CVE-2021-42740
+
+# @babel/traverse (example - dev dep)
+
+CVE-2023-45133

--- a/.trivyignore
+++ b/.trivyignore
@@ -25,3 +25,27 @@ CVE-2021-42740
 # @babel/traverse (example - dev dep)
 
 CVE-2023-45133
+
+# ip (example - dev dep)
+
+CVE-2023-42282
+
+# react-devtools-core (example - dev dep)
+
+CVE-2023-5654
+
+# activesupport (example - Gem)
+
+CVE-2023-38037
+
+# semver (nodejs-mobile-react-native app)
+
+CVE-2022-25883
+
+# tough-cookie (nodejs-mobile-react-native app)
+
+CVE-2023-26136
+
+# word-wrap (nodejs-mobile-react-native app)
+
+CVE-2023-26115

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -77,9 +77,9 @@ PODS:
     - gr4vy-ios (= 1.6.1)
     - React-Core
   - gr4vy-ios (1.6.1)
-  - hermes-engine (0.71.4):
-    - hermes-engine/Pre-built (= 0.71.4)
-  - hermes-engine/Pre-built (0.71.4)
+  - hermes-engine (0.71.8):
+    - hermes-engine/Pre-built (= 0.71.8)
+  - hermes-engine/Pre-built (0.71.8)
   - libevent (2.1.12)
   - nodejs-mobile-react-native (0.8.1):
     - React-Core
@@ -629,7 +629,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   gr4vy-embed-react-native: fa2c871707b970da45a94af0611e1c0ddeb70929
   gr4vy-ios: e983133ec0e3beed759e3ee07aeca7bb480c8b10
-  hermes-engine: a1f157c49ea579c28b0296bda8530e980c45bdb3
+  hermes-engine: 47986d26692ae75ee7a17ab049caee8864f855de
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   nodejs-mobile-react-native: e35e7ed7ecfca168f168983e9557f1c5278d864b
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c

--- a/example/package.json
+++ b/example/package.json
@@ -26,5 +26,8 @@
     "@babel/runtime": "^7.20.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "metro-react-native-babel-preset": "0.73.9"
+  },
+  "resolutions": {
+    "tar": "^6.2.1"
   }
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1975,10 +1975,10 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chownr@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
-  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -2657,12 +2657,12 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   dependencies:
-    minipass "^2.6.0"
+    minipass "^3.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3792,20 +3792,25 @@ minimist@^1.2.6:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass@^2.6.0, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+minipass@^3.0.0:
+  version "3.3.6"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
   dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
+    yallist "^4.0.0"
 
-minizlib@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
   dependencies:
-    minipass "^2.9.0"
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -3815,12 +3820,17 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.5:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.6"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -4638,7 +4648,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5037,18 +5047,17 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tar@^4.4.8:
-  version "4.4.19"
-  resolved "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
-  integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
+tar@^4.4.8, tar@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
-    chownr "^1.1.4"
-    fs-minipass "^1.2.7"
-    minipass "^2.9.0"
-    minizlib "^1.3.3"
-    mkdirp "^0.5.5"
-    safe-buffer "^5.2.1"
-    yallist "^3.1.1"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 temp@0.8.3:
   version "0.8.3"
@@ -5431,10 +5440,15 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.1.1:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
**Description:** Adds resolution to tar `^6.2.1`, fixing the vulnerability related to it https://github.com/gr4vy/gr4vy-react-native/security/dependabot/53. Also ignores a few vulnerabilities found by trivy that are not important and can only be fixed by upgrading the project.

**Note:** To test I had to downgrade to Xcode 14.3 (we originally set up the project with that version), as working with Xcode 15 would fail to launch the example app. We'd need to upgrade the React Native version, I created a ticket for it https://gr4vy.atlassian.net/browse/TA-6984