### PR TITLE
chore: upgrade android sdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,8 +67,8 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  
-  implementation "com.github.gr4vy:gr4vy-android:v1.7.4"
+
+  implementation "com.github.gr4vy:gr4vy-android:v1.9.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - gr4vy-embed-react-native (1.1.0):
+  - gr4vy-embed-react-native (1.2.0):
     - gr4vy-ios (= 2.2.1)
     - React-Core
   - gr4vy-ios (2.2.1)
@@ -627,7 +627,7 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  gr4vy-embed-react-native: 04bd89611a599568cada061b531d0e08439bde22
+  gr4vy-embed-react-native: 6931c33fa74abdfaa652e2c7c820b8abbd1df338
   gr4vy-ios: 9553ba573977441f837de5df83f855582d813401
   hermes-engine: 47986d26692ae75ee7a17ab049caee8864f855de
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - gr4vy-embed-react-native (1.2.0):
+  - gr4vy-embed-react-native (1.1.0):
     - gr4vy-ios (= 2.2.1)
     - React-Core
   - gr4vy-ios (2.2.1)
@@ -627,7 +627,7 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  gr4vy-embed-react-native: 6931c33fa74abdfaa652e2c7c820b8abbd1df338
+  gr4vy-embed-react-native: 04bd89611a599568cada061b531d0e08439bde22
   gr4vy-ios: 9553ba573977441f837de5df83f855582d813401
   hermes-engine: 47986d26692ae75ee7a17ab049caee8864f855de
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913


### PR DESCRIPTION
**Description:** Upgrades Android SDK to v1.9.0. Also tested with Android 34 and verified that things now work in Embed (re https://gr4vy.slack.com/archives/C02HS42MSV8/p1718625583698779)