### PR TITLE
task: add support for `connectionOptions`

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -53,6 +53,9 @@ CVE-2023-26115
 # rexml (react-native)
 
 CVE-2024-35176
+CVE-2024-39908
+CVE-2024-41123
+CVE-2024-41946
 
 # fast-xml-parser (react-native)
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -53,3 +53,7 @@ CVE-2023-26115
 # rexml (react-native)
 
 CVE-2024-35176
+
+# fast-xml-parser (react-native)
+
+CVE-2024-41818

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 
-  implementation "com.github.gr4vy:gr4vy-android:v1.9.0"
+  implementation "com.github.gr4vy:gr4vy-android:v1.10.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,6 +69,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
 
   implementation "com.github.gr4vy:gr4vy-android:v1.10.0"
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/gr4vy/embedreactnative/EmbedReactNativeModule.java
+++ b/android/src/main/java/com/gr4vy/embedreactnative/EmbedReactNativeModule.java
@@ -29,6 +29,9 @@ import android.util.Log;
 import org.json.JSONObject;
 import org.json.JSONException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 @ReactModule(name = EmbedReactNativeModule.NAME)
 public class EmbedReactNativeModule extends ReactContextBaseJavaModule {
   public static final String NAME = "EmbedReactNative";
@@ -166,37 +169,17 @@ public class EmbedReactNativeModule extends ReactContextBaseJavaModule {
     return cartItemsWritableArray;
   }
 
-  private static JSONObject convertMapToJsonObject(ReadableMap map) {
-    JSONObject jsonObject = new JSONObject();
-    ReadableMapKeySetIterator iterator = map.keySetIterator();
+  private static String convertMapToJsonString(ReadableMap map) {
+    ObjectMapper objectMapper = new ObjectMapper();
 
-    while (iterator.hasNextKey()) {
-      String key = iterator.nextKey();
-
-      try {
-        switch (map.getType(key)) {
-          case Null:
-            jsonObject.put(key, null);
-            break;
-          case Boolean:
-            jsonObject.put(key, map.getBoolean(key));
-            break;
-          case Number:
-            jsonObject.put(key, map.getDouble(key));
-            break;
-          case String:
-            jsonObject.put(key, map.getString(key));
-            break;
-          case Map:
-            jsonObject.put(key, convertMapToJsonObject(map.getMap(key)));
-            break;
-        }
-      } catch (JSONException e) {
-        e.printStackTrace();
-      }
+    try {
+      String jsonString = objectMapper.writeValueAsString(map.toHashMap());
+      return jsonString;
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
     }
 
-    return jsonObject;
+    return null;
   }
 
   @Override
@@ -286,7 +269,7 @@ public class EmbedReactNativeModule extends ReactContextBaseJavaModule {
       androidIntent.putExtra(EXTRA_REQUIRE_SECURITY_CODE, requireSecurityCode);
       androidIntent.putExtra(EXTRA_SHIPPING_DETAILS_ID, shippingDetailsId);
       androidIntent.putExtra(EXTRA_MERCHANT_ACCOUNT_ID, merchantAccountid);
-      androidIntent.putExtra(EXTRA_CONNECTION_OPTIONS_STRING, convertMapToJsonObject(connectionOptions).toString());
+      androidIntent.putExtra(EXTRA_CONNECTION_OPTIONS_STRING, convertMapToJsonString(connectionOptions));
       androidIntent.putExtra(EXTRA_DEBUG_MODE, debugMode);
 
       context.startActivityForResult(androidIntent, GR4VY_PAYMENT_SHEET_REQUEST, null);

--- a/android/src/main/java/com/gr4vy/embedreactnative/EmbedReactNativeModule.java
+++ b/android/src/main/java/com/gr4vy/embedreactnative/EmbedReactNativeModule.java
@@ -10,7 +10,6 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -25,9 +24,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
-
-import org.json.JSONObject;
-import org.json.JSONException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/android/src/main/java/com/gr4vy/embedreactnative/Gr4vyActivity.java
+++ b/android/src/main/java/com/gr4vy/embedreactnative/Gr4vyActivity.java
@@ -46,6 +46,7 @@ import static com.gr4vy.embedreactnative.EmbedReactNativeModule.EXTRA_MERCHANT_A
 import static com.gr4vy.embedreactnative.EmbedReactNativeModule.EXTRA_DEBUG_MODE;
 import static com.gr4vy.embedreactnative.EmbedReactNativeModule.EXTRA_PAYMENT_SOURCE;
 import static com.gr4vy.embedreactnative.EmbedReactNativeModule.EXTRA_CART_ITEMS;
+import static com.gr4vy.embedreactnative.EmbedReactNativeModule.EXTRA_CONNECTION_OPTIONS_STRING;
 
 public class Gr4vyActivity extends ComponentActivity implements Gr4vyResultHandler {
   private Gr4vySDK gr4vySDK;
@@ -79,6 +80,7 @@ public class Gr4vyActivity extends ComponentActivity implements Gr4vyResultHandl
   Boolean requireSecurityCode;
   String shippingDetailsId;
   String merchantAccountId;
+  String connectionOptionsString;
   Boolean debugMode;
 
   Boolean sdkLaunched = false;
@@ -250,6 +252,7 @@ public class Gr4vyActivity extends ComponentActivity implements Gr4vyResultHandl
     this.shippingDetailsId = intent.getStringExtra(EXTRA_SHIPPING_DETAILS_ID);
     this.merchantAccountId = intent.getStringExtra(EXTRA_MERCHANT_ACCOUNT_ID);
     this.locale = intent.getStringExtra(EXTRA_LOCALE);
+    this.connectionOptionsString = intent.getStringExtra(EXTRA_CONNECTION_OPTIONS_STRING);
     this.debugMode = intent.getExtras().getBoolean(EXTRA_DEBUG_MODE);
 
     // Convert the cartItems JSON string to List<CartItem>
@@ -314,7 +317,8 @@ public class Gr4vyActivity extends ComponentActivity implements Gr4vyResultHandl
             requireSecurityCode,
             shippingDetailsId,
             merchantAccountId,
-            null, // TODO: pass connectionOptions
+            null,
+            connectionOptionsString,
             debugMode);
 
     sdkLaunched = true;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,10 +73,10 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - gr4vy-embed-react-native (1.3.0):
-    - gr4vy-ios (= 2.2.1)
+  - gr4vy-embed-react-native (1.4.0):
+    - gr4vy-ios (= 2.3.0)
     - React-Core
-  - gr4vy-ios (2.2.1)
+  - gr4vy-ios (2.3.0)
   - hermes-engine (0.71.8):
     - hermes-engine/Pre-built (= 0.71.8)
   - hermes-engine/Pre-built (0.71.8)
@@ -627,8 +627,8 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  gr4vy-embed-react-native: 79b8285825a3d91e2d283abca22b420b1d61e763
-  gr4vy-ios: 9553ba573977441f837de5df83f855582d813401
+  gr4vy-embed-react-native: 7e6c93a6fe86730c713d06dc4166466cf5c1b4d7
+  gr4vy-ios: 6da4b6379e86aeb89d1cf13cc3749ae21d9dee25
   hermes-engine: 47986d26692ae75ee7a17ab049caee8864f855de
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   nodejs-mobile-react-native: e35e7ed7ecfca168f168983e9557f1c5278d864b

--- a/gr4vy-embed-react-native.podspec
+++ b/gr4vy-embed-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "gr4vy-ios", "2.2.1"
+  s.dependency "gr4vy-ios", "2.3.0"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/ios/EmbedReactNative.swift
+++ b/ios/EmbedReactNative.swift
@@ -29,6 +29,7 @@ class EmbedReactNative: NSObject {
                  requireSecurityCode: Bool?,
                  shippingDetailsId: String?,
                  merchantAccountId: String?,
+                 connectionOptions: String?,
                  debugMode: Bool = false,
                  completion: @escaping(_ gr4vy: Gr4vy?) -> Void)  {
     var paymentSourceConverted: Gr4vyPaymentSource?
@@ -59,6 +60,7 @@ class EmbedReactNative: NSObject {
                               requireSecurityCode: requireSecurityCode,
                               shippingDetailsId: shippingDetailsId,
                               merchantAccountId: merchantAccountId,
+                              connectionOptionsString: connectionOptions,
                               debugMode: debugMode) else {
         completion(nil)
         return
@@ -228,6 +230,24 @@ class EmbedReactNative: NSObject {
     return nil
   }
 
+  func convertObjectToJsonString(_ obj: [String: [String: String?]?]?) -> String? {
+    guard let obj = obj else {
+      return nil
+    }
+
+    do {
+      let jsonData = try JSONSerialization.data(withJSONObject: obj, options: [])
+
+      if let jsonString = String(data: jsonData, encoding: .utf8) {
+        return jsonString
+      } else {
+        return nil
+      }
+    } catch {
+      return nil
+    }
+  }
+
   @objc
   func constantsToExport() -> [AnyHashable : Any]! {
     return [
@@ -262,6 +282,7 @@ class EmbedReactNative: NSObject {
           let requireSecurityCode = config["requireSecurityCode"] as? Bool?,
           let shippingDetailsId = config["shippingDetailsId"] as? String?,
           let merchantAccountId = config["merchantAccountId"] as? String?,
+          let connectionOptions = config["connectionOptions"] as? [String: [String: String?]?]?,
           let debugMode = config["debugMode"] as? Bool?
     else {
         EmbedReactNativeEvents.emitter.sendEvent(
@@ -298,6 +319,7 @@ class EmbedReactNative: NSObject {
              requireSecurityCode: requireSecurityCode,
              shippingDetailsId: shippingDetailsId,
              merchantAccountId: merchantAccountId,
+             connectionOptions: convertObjectToJsonString(connectionOptions),
              debugMode: debugMode ?? false) { (gr4vy) in
       if gr4vy == nil {
         EmbedReactNativeEvents.emitter.sendEvent(

--- a/src/EmbedReactNative.ts
+++ b/src/EmbedReactNative.ts
@@ -107,6 +107,7 @@ export type Gr4vyConfig = {
   requireSecurityCode?: boolean
   shippingDetailsId?: string
   merchantAccountId?: string
+  connectionOptions?: Record<string, unknown>
   debugMode?: boolean
 }
 


### PR DESCRIPTION
**Description:** Adds support for passing a connection options config in the form of a JSON string via `connectionOptionsString`. Merchants are still able to pass a javascript object via `connectionOptions`, but internally we convert that to a JSON string and pass it to the mobile SDKs. To do that on the Java side, we use a library to make things easier https://github.com/FasterXML/jackson-databind (will probably reuse it to optimize other code)

**Ticket:** https://gr4vy.atlassian.net/browse/TA-7609

![Screenshot 2024-08-13 at 11 08 44](https://github.com/user-attachments/assets/12c56886-87bb-4fc4-9a7c-f6234ec1996a)

![Screenshot 2024-08-13 at 10 05 04](https://github.com/user-attachments/assets/d2d3c8ce-fba5-4ede-9727-184081f3d7d3)

(using `NonSensitiveField` locally to double-check the passed values are used)

<img width="1406" alt="Screenshot 2024-08-13 at 16 47 44" src="https://github.com/user-attachments/assets/296f79b4-d5b8-4e48-950d-2fcee3f0cb81">

