### PR TITLE
trivy-db repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
           ignore-unfixed: true
           skip-dirs: node_modules
           exit-code: 1
+        env:
+          TRIVY_DB_REPOSITORY: us-docker.pkg.dev/gr4vy-admin/ghcr/aquasecurity/trivy-db
 
   release:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository_owner == 'gr4vy' && github.ref == 'refs/heads/main'"


### PR DESCRIPTION

Jira: [PE-860](https://gr4vy.atlassian.net/browse/PE-860)

Trivy scans the source code and any container image for vulnerabilities. However, when using the default repository for the trivy database, we see rate limiting issues:
```
Fatal error	init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
	* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 669.3µs, allowed: 44000/minute
```

This has been widely reported on the Trivy git repositories and the Trivy maintainers are making changes in an attempt to improve the situation. However it's unclear how long these changes will take and it appears the changes will only be available in the latest versions. We often pin to an older version of trivy because of [another issue](https://gr4vy.atlassian.net/browse/PE-267) (of our own making).

We've have setup a Google Artifact Registry "remote repository" which effectively caches images from the default GitHub Container Registry. This PR updates the settings trivy uses to get the database from this cache, and avoiding the rate limiting from ghcr.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>