### PR TITLE
trivy-db repository (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           skip-dirs: node_modules
           exit-code: 1
         env:
-          TRIVY_DB_REPOSITORY: us-docker.pkg.dev/gr4vy-admin/ghcr/aquasecurity/trivy-db
+          TRIVY_DB_REPOSITORY: us-docker.pkg.dev/gr4vy-admin/aquasecurity/trivy-db
 
   release:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository_owner == 'gr4vy' && github.ref == 'refs/heads/main'"


### PR DESCRIPTION

Jira:
- [PE-860](https://gr4vy.atlassian.net/browse/PE-860)
- [PE-896](https://gr4vy.atlassian.net/browse/PE-896)

Trivy scans the source code and any container image for vulnerabilities. However, when using the default repository for the trivy database, we see rate limiting issues from GitHub Container Registry:
```
Fatal error	init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
	* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 669.3µs, allowed: 44000/minute
```

This has been widely reported on the Trivy git repositories and the Trivy maintainers are making changes in an attempt to improve the situation. However it's unclear how long these changes will take and it appears the changes will only be available in the latest versions.

We've previously setup a Google Artifact Registry "remote repository" which effectively caches images from the default GitHub Container Registry. However, this has not been as successful as we had hoped because the Google Artifact Registry remote repository still has to go to GitHub Container Registry to collect new images, and we experience the rate limiting errors again.

We now have a new, standard, Google Artifact Registry image repository to hold the `trivy-db` images. This is updated from a scheduled job every 6 hours, rather than pulling new images when Trivy executes. This may result in Trivy using a slightly older vulnerabilities database, but should ensure that when executing Trivy there's always a `trivy-db` image available.

This PR updates the settings trivy uses to get the database from this new repository, and avoiding the rate limiting from ghcr.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>

[PE-860]: https://gr4vy.atlassian.net/browse/PE-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PE-896]: https://gr4vy.atlassian.net/browse/PE-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ