### PR TITLE
Trivy supply chain attack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION

An attacker compromised Aquasec Trivy and made changes to inject malicious code designed to collect sensitive information like API tokens, cloud credentials (AWS, GCP, Azure), SSH keys, Docker configuration files, Git credentials, and other secrets available within CI/CD systems.

This PR updates our usage of Trivy to known safe versions:
 - Trivy binary v0.69.3
 - trivy-action v0.35.0
 - setup-trivy v0.2.65

This PR is also pinning GitHub Actions to full, immutable commit SHA hashes — not mutable version tags. Version tags can be moved to point at malicious commits, as demonstrated in this attack. For example:

```
# UNSAFE — mutable tag, can be silently redirected to malicious code
uses: aquasecurity/trivy-action@v0.35.0
# SAFE — pinned to an immutable commit SHA
uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
```

We're taking the same approach with the container image we use, pulling the image digest (SHA-256 hash) not the tag. Unlike tags, which can be reused or changed, a digest is immutable and ensures that the exact same image is pulled every time.


Docs:
- [Trivy blog post](https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/)
- [GitHub security advisory](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>