### PR TITLE
fix: fast-xml-parser 4.5.4 vulnerability

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -39,7 +39,7 @@
     "semver": "^7.6.3",
     "on-headers": "^1.1.0",
     "qs": "^6.14.1",
-    "fast-xml-parser": "^4.5.4",
+    "fast-xml-parser": "^4.5.5",
     "picomatch": "^2.3.2"
   }
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3877,10 +3877,10 @@ fast-json-stable-stringify@^2.1.0:
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-xml-parser@^4.4.1, fast-xml-parser@^4.5.4:
-  version "4.5.4"
-  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz#64e52ddf1308001893bd225d5b1768840511c797"
-  integrity sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==
+fast-xml-parser@^4.4.1, fast-xml-parser@^4.5.5:
+  version "4.5.6"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz#4ff57d4aca13a2d11aa42ad460495cf00f32b655"
+  integrity sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
**Description:** Fixes https://github.com/gr4vy/gr4vy-react-native/security/dependabot/201 by bumping the patch version of the existing yarn resolution. This vulnerability is due in 5 days.