### PR TITLE
chore: remove unsafe npx references

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
         node-version-file: .nvmrc
 
     - name: Upgrade npm for trusted publishing (needs npm >= 11.5.1)
-      run: npm install -g npm@^11.5.1
+      run: npm install -g npm@11.13.0
       shell: bash
 
     - name: Cache dependencies

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,8 +4,8 @@ pre-commit:
     lint:
       files: git diff --name-only @{push}
       glob: '*.{js,ts,jsx,tsx}'
-      run: npx eslint {files}
+      run: npx --no eslint {files}
     types:
       files: git diff --name-only @{push}
       glob: '*.{js,ts, jsx, tsx}'
-      run: npx tsc --noEmit
+      run: npx --no tsc --noEmit

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,8 +4,8 @@ pre-commit:
     lint:
       files: git diff --name-only @{push}
       glob: '*.{js,ts,jsx,tsx}'
-      run: npx --no eslint {files}
+      run: yarn eslint {files}
     types:
       files: git diff --name-only @{push}
       glob: '*.{js,ts, jsx, tsx}'
-      run: npx --no tsc --noEmit
+      run: yarn tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepack": "bob build",
     "release": "auto shipit",
     "example": "yarn --cwd example",
-    "bootstrap": "yarn example && yarn install && yarn example pods",
+    "bootstrap": "yarn example && yarn install --frozen-lockfile && yarn example pods",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build"
   },
   "keywords": [


### PR DESCRIPTION
TA-16142
TA-16150

Favour `npx --no` to skip installing extra dependencies if not installed in the local environment.