### PR TITLE
fix: unblock trivy scan by suppressing non-shipped jwt CVE-2026-45363

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -19,3 +19,11 @@ CVE-2026-33176
 # image-size
 
 GHSA-m5qc-5hw7-8vg7
+# jwt 2.8.2 — CVE-2026-45363 (ruby-jwt empty-key HMAC bypass).
+# Transitive dev-only dependency of fastlane (2.222.0) in example/ios and
+# example/android, which pins jwt < 3; the fix lands in 3.2.0, so it cannot be
+# bumped without a fastlane major upgrade. The example app's Ruby tooling is not
+# part of the published @gr4vy/embed-react-native package, so this is not
+# reachable by SDK consumers.
+
+CVE-2026-45363


### PR DESCRIPTION
## Problem

The `scan` (Trivy) CI job fails on **every** PR (including #201), blocking merges. It is not caused by any PR’s changes — the Trivy DB started flagging a HIGH vuln in a pre-existing dependency:

| Library | CVE | Severity | Installed | Fixed in |
|---|---|---|---|---|
| `jwt` | CVE-2026-45363 (ruby-jwt empty-key HMAC bypass) | HIGH | 2.8.2 | 3.2.0 |

The scan runs `trivy fs .` with `exit-code: 1`, so a single fixed-but-unpatched finding fails the job.

## Why not just bump the gem

`jwt` is a **transitive dev-only dependency of fastlane 2.222.0** in `example/ios/Gemfile.lock` and `example/android/Gemfile.lock`. Fastlane pins `jwt (>= 2.1.0, < 3)`, and the fix only lands in `3.2.0` — so it cannot be force-pinned the way `rexml` / `faraday` / `aws-sdk-s3` already are in the example `Gemfile`. Resolving it properly would require a fastlane major upgrade.

Crucially, the `example/` app is **not part of the published `@gr4vy/embed-react-native` package** (it’s excluded from the npm `files` whitelist), so this vulnerability is never reachable by SDK consumers.

## Fix

Add `CVE-2026-45363` to `.trivyignore` with a justifying comment — matching how this repo already suppresses other non-applicable Ruby CVEs (e.g. the activesupport DoS ones).

## Follow-up

A cleaner long-term fix is to bump fastlane to a version that allows `jwt >= 3.2.0`, then drop this ignore entry. Tracked as a separate task.