### PR TITLE
fix: restore npm 11 upgrade step for trusted publishing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,6 +9,10 @@ runs:
       with:
         node-version-file: .nvmrc
 
+    - name: Upgrade npm for trusted publishing (needs npm >= 11.5.0)
+      run: npm install -g npm@11
+      shell: bash
+
     - name: Cache dependencies
       id: yarn-cache
       uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3


### PR DESCRIPTION
It re-adds the `npm install -g npm@11` step that #195 removed. The repo publishes via OIDC trusted publishing (#95), which needs npm >= 11.5, so without it CI fell back to npm 10.9.8 and `npm publish` ran unauthenticated, returning the misleading `404 PUT` in #209.

Pinned to the `11` major to stay OIDC-capable without jumping to the npm 12 prerelease.