### PR TITLE
fix: upgrade to gr4vy-android 2.0.0 and fix the store option pass-through

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 
-  implementation "com.github.gr4vy:gr4vy-android:v1.14.0"
+  implementation "com.github.gr4vy:gr4vy-android:v2.0.0"
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
 }
 

--- a/android/src/main/java/com/gr4vy/embedreactnative/EmbedReactNativeModule.java
+++ b/android/src/main/java/com/gr4vy/embedreactnative/EmbedReactNativeModule.java
@@ -242,8 +242,6 @@ public class EmbedReactNativeModule extends ReactContextBaseJavaModule {
           store = config.getString("store");
         } else if (config.getType("store") == ReadableType.Boolean) {
           store = String.valueOf(config.getBoolean("store"));
-        } else {
-          store = null;
         }
       }
 

--- a/android/src/main/java/com/gr4vy/embedreactnative/Gr4vyActivity.java
+++ b/android/src/main/java/com/gr4vy/embedreactnative/Gr4vyActivity.java
@@ -75,7 +75,7 @@ public class Gr4vyActivity extends ComponentActivity implements Gr4vyResultHandl
   String country;
   String buyerId;
   String externalIdentifier;
-  String store;
+  Gr4vyStore store;
   String display;
   String intent;
   List<CartItem> cartItems;
@@ -281,7 +281,6 @@ public class Gr4vyActivity extends ComponentActivity implements Gr4vyResultHandl
     this.country = intent.getStringExtra(EXTRA_COUNTRY);
     this.buyerId = intent.getStringExtra(EXTRA_BUYER_ID);
     this.externalIdentifier = intent.getStringExtra(EXTRA_EXTERNAL_IDENTIFIER);
-    this.store = intent.getStringExtra(EXTRA_STORE);
     this.display = intent.getStringExtra(EXTRA_DISPLAY);
     this.intent = intent.getStringExtra(EXTRA_INTENT);
     this.buyerExternalIdentifier = intent.getStringExtra(EXTRA_BUYER_EXTERNAL_IDENTIFIER);
@@ -324,6 +323,13 @@ public class Gr4vyActivity extends ComponentActivity implements Gr4vyResultHandl
       paymentSourceString != null ?
         PaymentSource.valueOf(paymentSourceString.toUpperCase()) :
         PaymentSource.NOT_SET;
+
+    // Set store according to its type requirements
+    String storeString = intent.getStringExtra(EXTRA_STORE);
+    this.store =
+      storeString != null ?
+        Gr4vyStore.valueOf(storeString.toUpperCase()) :
+        null;
 
     this.gr4vySDK = new Gr4vySDK(activityResultRegistry, this, this);
     getLifecycle().addObserver(this.gr4vySDK);


### PR DESCRIPTION
**Description:** Applies the gr4vy-android fix for the `store` option https://github.com/gr4vy/gr4vy-android/pull/32. Along with upgrading the version, it also processes the type correctly with the new `Gr4vyStore` model. Tested locally with the emulator and different `store` scenarios.

**Ticket:** https://gr4vy.atlassian.net/browse/TA-17684